### PR TITLE
Update requirements to prevent gensim breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 We provided the evaluation script using target function proposed in the manuscript, as well as a gene2vec file in word2vec format.
 
 ## Introduction
-Gene2Vec is a distributed representation of genes based on co-expression. From a pure data-driven fashion, we trained a 
+Gene2Vec is a distributed representation of genes based on co-expression. From a pure data-driven fashion, we trained a
 200-dimension vector representation of all human genes, using gene co-expression patterns in 984 data sets from the GEO databases.
 
 In this repository, we provided the relevent codes as well as pre-trained gene2vec files.
@@ -24,6 +24,8 @@ git clone https://github.com/jingcheng-du/Gene2vec.git
 cd Gene2vec/
 pip install -r requirements.txt
 ```
+
+*NOTE: If you get an error with `certifi`, add `--ignore-installed certifi` to the end of the `pip install` command.*
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 tensorflow>=1.6.0
-gensim>=3.4.0
+gensim==3.4.0
 numpy>=1.14.0
 matplotlib>=2.1.2
+scikit-learn==0.18.2
+scipy==1.2.0
+MulticoreTSNE==0.1


### PR DESCRIPTION
Dear authors, thank you for the useful package. With updates to `gensim`, `scipy` and `scikit-learn`, the old `requirements.txt` file no longer works. This pull request resolves that.

In the original `requirements.txt` file, `gensim >=3.4` was specified. After the release of `gensim >=4`, API changes prevented code from running. The new requirements file fixes `gensim` at `3.4`.

Errors were obtained when running with some versions of `scikit-learn` and `scipy`. `scikit-learn==0.18.2` and `scipy==1.2.0` were tested and found to work.

`MulticoreTSNE==0.1` was also added to requirements file.

Finally, existing installs of `certifi` may cause problems. This can be fixed by specifying `--ignore-install certifi` to `pip install`. `README.md` was updated with this note.